### PR TITLE
Show system even though system version is not selected

### DIFF
--- a/libexec/grnenv-versions
+++ b/libexec/grnenv-versions
@@ -17,4 +17,6 @@ done
 
 if [ $current_version = "system" ]; then
   echo "* system ($(grnenv-which groonga))"
+else
+  echo "  system"
 fi


### PR DESCRIPTION
If system version is not selected, grnenv versions command doesn't
show "system". It seems that system version of Groonga is not
recognized. It causes misreading to grnenv user.