### PR TITLE
Apply patch for OpenSSL 1.1.x

### DIFF
--- a/libexec/grnenv-build
+++ b/libexec/grnenv-build
@@ -40,5 +40,7 @@ case $OPENSSL_VERSION in
 	;;
 esac
 ./configure --prefix=$GRNENV_HOME/versions/$version
+# Suppress fallthrough error with GCC 7.x
+sed -i'' -e 's/-Werror/-Werror=implicit-fallthrough=0/' vendor/nginx-*/objs/Makefile
 make
 make install

--- a/libexec/grnenv-build
+++ b/libexec/grnenv-build
@@ -19,6 +19,26 @@ wget https://packages.groonga.org/source/groonga/groonga-$version.tar.gz
 tar xzvf groonga-$version.tar.gz
 cd groonga-$version
 
+# It needs patch to build with OpenSSL 1.1.x between Groonga 6.0.3 and 6.0.8.
+OPENSSL_PATCH=$GRNENV_HOME/patches/fix-nginx-build-error-with-openssl-1.1.patch
+OPENSSL_VERSION=$(pkg-config --modversion openssl)
+case $OPENSSL_VERSION in
+    1\.1\.*)
+	case $version in
+	    6\.0\.[3-8])
+		# NOTE: 6.0.0 - 6.0.2 needs more patch to support OpenSSL 1.1.x
+		echo "apply $OPENSSL_PATCH"
+		(cd vendor/nginx-* && patch -p3 < $OPENSSL_PATCH)
+		;;
+	    *)
+		echo "No need to apply $OPENSSL_PATCH"
+		;;
+	esac
+	;;
+    *)
+	echo "No need to apply patch older than OpenSSL 1.1.x"
+	;;
+esac
 ./configure --prefix=$GRNENV_HOME/versions/$version
 make
 make install

--- a/patches/fix-nginx-build-error-with-openssl-1.1.patch
+++ b/patches/fix-nginx-build-error-with-openssl-1.1.patch
@@ -1,0 +1,13 @@
+Author: Kurt Cancemi <kurt@x64architecture.com>
+Description: Fix build error which is caused by removed OpenSSL unused error codes
+Forwarded: yes
+--- a/vendor/nginx-1.11.1/src/event/ngx_event_openssl.c
++++ b/vendor/nginx-1.11.1/src/event/ngx_event_openssl.c
+@@ -1999,7 +1999,6 @@
+             || n == SSL_R_ERROR_IN_RECEIVED_CIPHER_LIST              /*  151 */
+             || n == SSL_R_EXCESSIVE_MESSAGE_SIZE                     /*  152 */
+             || n == SSL_R_LENGTH_MISMATCH                            /*  159 */
+-            || n == SSL_R_NO_CIPHERS_PASSED                          /*  182 */
+             || n == SSL_R_NO_CIPHERS_SPECIFIED                       /*  183 */
+             || n == SSL_R_NO_COMPRESSION_SPECIFIED                   /*  187 */
+             || n == SSL_R_NO_SHARED_CIPHER                           /*  193 */


### PR DESCRIPTION
There are some versions which requires patch to build with OpenSSL 1.1.x.
This PR supports Groonga 6.0.3 - 6.0.8 with OpenSSL 1.1.x.

Note that 6.0.0 - 6.0.2 needs more fixes to support it.
